### PR TITLE
Freeze discord api 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # github notifications bot project
- github notifications discord bot project
+
+github notifications discord bot project
+
+# Installation instructions.
+
+## virtualenv
+
+> python -m venv venv
+
+This instruction will work on POSIX system. ie, in Windows probably won't work
+
+> source venv/bin/activate
+
+This may be different on windows, take a look here https://docs.python.org/3/library/venv.html
+Search for "activate" in your browser, and take a look at the table with headers:
+
+Platform | Shell | Command to activate virtual environment
+
+If you are using Windows, take a look at the row that reads "Windows", there 
+
+To read the dependencies and start using the project, run this command:
+
+> pip install -r requirements.txt
+
+I didn't test it. Please remove this last comment if you didn't have any problems. Otherwise, write here what you did to fix the problem
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+aiohttp==3.8.2
+aiosignal==1.2.0
+async-timeout==4.0.2
+attrs==22.1.0
+charset-normalizer==2.1.1
+discord==2.0.0
+discord.py==2.0.1
+frozenlist==1.3.1
+idna==3.4
+multidict==5.2.0
+yarl==1.8.1


### PR DESCRIPTION
I've created this PR as a draft, a preview to see what gets broken with discord api 2.0.0. I suggest only merge these changes when we have a working `bot.py` file. I've tried to make the bot work with discord api 2.0.0, but I couldn't. You can take a look at my attempt on this branch that starts from this commit. https://github.com/KarlHeitmann/github-notifications-bot-project/tree/migrating_discord_api_v2.0.0

To get the migration done, I suggest either to start working on that branch or to sit on top of this `freeze_discord_api_2.0.0` branch, see what is broken on `bot.py`, and try to fix it from scratch by yourself. The goal is to make the bot work with discord api 2.0.0, I don't care about which path we may take.

In the meantime, I'll be working on getting these github notifications in another branch.